### PR TITLE
feat: improve Okta user provisioning automation

### DIFF
--- a/.github/workflows/okta-user-provision.yml
+++ b/.github/workflows/okta-user-provision.yml
@@ -1,8 +1,9 @@
+---
 name: Provision Okta User from Issue
 
-on:
+'on':
   issues:
-    types: [opened, reopened, edited]
+    types: [opened]
 
 permissions:
   contents: write
@@ -46,8 +47,12 @@ jobs:
           echo "EMAIL=$EMAIL" >> $GITHUB_ENV
           echo "REVIEWER=$REVIEWER" >> $GITHUB_ENV
 
-          FILENAME=$(echo "$EMAIL" | sed 's/@/-at-/g' | sed 's/[^a-zA-Z0-9._-]//g')
-          echo "FILENAME=$FILENAME" >> $GITHUB_ENV
+            FILENAME=$(echo "$EMAIL" \
+              | sed 's/@/-at-/g' \
+              | sed 's/[^a-zA-Z0-9._-]//g')
+            TIMESTAMP=$(date +%Y%m%d%H%M%S)
+            FILENAME="${FILENAME}-${TIMESTAMP}"
+            echo "FILENAME=$FILENAME" >> $GITHUB_ENV
 
       - name: Create JSON file
         run: |
@@ -81,6 +86,6 @@ jobs:
           body: |
             🎯 Oktaユーザー作成のPRです。
             内容を確認し、レビュワーは ${{ env.REVIEWER }} です。
-          add-paths: user-json/*.json
+          add-paths: user-json/${{ env.FILENAME }}.json
           reviewers: ${{ env.REVIEWER }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-user-json.yml
+++ b/.github/workflows/publish-user-json.yml
@@ -1,0 +1,40 @@
+---
+name: Publish approved Okta user
+
+'on':
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    if: github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'user-json-')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Copy JSON to GitHub Pages
+        run: |
+          mkdir -p public/users public/notifications
+          CHANGED_FILES=$(git diff --name-only \
+            ${{ github.event.pull_request.base.sha }} \
+            ${{ github.event.pull_request.merge_commit_sha }} \
+            | grep '^user-json/' || true)
+          for file in $CHANGED_FILES; do
+            base=$(basename "$file")
+            cp "$file" "public/users/$base"
+            echo "User JSON $base has been approved" \
+              > "public/notifications/${base%.json}.txt"
+          done
+
+      - name: Commit and push
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add public/users public/notifications
+          git commit -m "Publish approved user JSON" \
+            || echo "No changes to commit"
+          git push


### PR DESCRIPTION
## Summary
- trigger provisioning workflow only when a new issue is opened
- create JSON files with timestamped names
- publish approved user data to GitHub Pages instead of Slack

## Testing
- `yamllint .github/workflows/okta-user-provision.yml .github/workflows/publish-user-json.yml .github/ISSUE_TEMPLATE/okta-user-form.yml`


------
https://chatgpt.com/codex/tasks/task_e_688d7f0f61bc8327839095ae20178006